### PR TITLE
Required param clientlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install
 ### Creating Clientlib for AEM 65
 In AEM 65, core-component themes are deployed as clientlibs. To create clientlib from theme:
 ```
-npm run create-clientlib --category="adaptiveform.theme.canvas3"
+npm run create-clientlib --category="adaptiveform.theme.yourtheme"
 ```
 This takes to args 
 1. category : Clientlib category

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In AEM 65, core-component themes are deployed as clientlibs. To create clientlib
 npm run create-clientlib --category="adaptiveform.theme.yourtheme"
 ```
 This takes to args 
-1. category : Clientlib category
+1. category [Required] : Clientlib category
 2. directory : Where should the clientlib be created
 
 ### Environment Variables

--- a/clientlib-generator.js
+++ b/clientlib-generator.js
@@ -4,14 +4,16 @@ var process = require("process");
 
 
 const CLIENTLIB_DIR = process.env.npm_config_directory || "theme-clientlibs"
-const CLIENTLIB_CATEGORY = process.env.npm_config_category || "adaptiveform.theme.canvas3"
+const CLIENTLIB_CATEGORY = process.env.npm_config_category
 
-
+if(!!!CLIENTLIB_CATEGORY){
+  throw 'category parameter should be present'
+}
 clientlib(
   [
     {
       categories: [CLIENTLIB_CATEGORY],
-      name: "canvas3",
+      name: CLIENTLIB_CATEGORY,
       cssProcessor: ["default:none", "min:none"],
       jsProcessor: ["default:none", "min:gcc;compilationLevel=whitespace"],
       allowProxy: true,

--- a/clientlib-generator.js
+++ b/clientlib-generator.js
@@ -6,7 +6,7 @@ var process = require("process");
 const CLIENTLIB_DIR = process.env.npm_config_directory || "theme-clientlibs"
 const CLIENTLIB_CATEGORY = process.env.npm_config_category
 
-if(!!!CLIENTLIB_CATEGORY){
+if(!CLIENTLIB_CATEGORY){
   throw 'category parameter should be present'
 }
 clientlib(

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "create-zip": "cd dist/ && zip ./theme.zip ./* -r",
         "deploy-zip": "node scripts/deploy-zip.mjs",
         "clientlib-generator":"node clientlib-generator.js",
-        "create-clientlib": "npm run build && npm run clientlib-generator --category=adaptiveform.theme.canvas3"
+        "create-clientlib": "npm run build && npm run clientlib-generator"
     },
     "devDependencies": {
         "@aemforms/aem-site-theme-builder": "5.3.0",


### PR DESCRIPTION
Make the Clientlib parameter required before creating a theme clientlib
This is done so that the customer does not use the canvas3 clientlib category be default as it can create problems.