### PR TITLE
Adding post css processing to keep old media query syntax (max-, min-)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "parcel": "^2.0.1",
                 "parcel-namer-rewrite": "^2.0.0-rc.1",
                 "path": "^0.12.7",
+                "postcss-media-minmax": "^5.0.0",
                 "process": "^0.11.10",
                 "rimraf": "^3.0.2",
                 "stylelint": "^14.16.1",
@@ -8851,6 +8852,18 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
+        "node_modules/postcss-media-minmax": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
+            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
         "node_modules/postcss-media-query-parser": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -17020,6 +17033,13 @@
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             }
+        },
+        "postcss-media-minmax": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
+            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+            "dev": true,
+            "requires": {}
         },
         "postcss-media-query-parser": {
             "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -29,16 +29,17 @@
         "parcel": "^2.0.1",
         "parcel-namer-rewrite": "^2.0.0-rc.1",
         "path": "^0.12.7",
+        "postcss-media-minmax": "^5.0.0",
         "process": "^0.11.10",
         "rimraf": "^3.0.2",
-        "typescript": "^4.5.2",
-        "stylelint-scss": "5.2.1",
-        "stylelint-csstree-validator": "3.0.0",
         "stylelint": "^14.16.1",
         "stylelint-config-standard": "^25.0.0",
         "stylelint-config-standard-scss": "^4.0.0",
+        "stylelint-csstree-validator": "3.0.0",
         "stylelint-formatter-pretty": "^3.1.1",
-        "stylelint-use-logical-spec": "^5.0.0"
+        "stylelint-scss": "5.2.1",
+        "stylelint-use-logical-spec": "^5.0.0",
+        "typescript": "^4.5.2"
     },
     "dependencies": {
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "Standard AEM Forms Canvas theme",
     "license": "MIT License, Copyright 2022 Adobe Systems Incorporated",
     "scripts": {
-        "build": "rimraf dist && mkdir dist && parcel build src/theme.ts --no-cache --dist-dir dist",
+        "build": "rimraf dist && mkdir dist && parcel build src/theme.ts --no-cache --dist-dir dist && npm run postcss",
+        "postcss": "node post-css.js",
         "watch": "parcel watch src/theme.ts",
         "proxy": "aem-site-theme-builder live",
         "live": "npm-run-all -p watch proxy",
@@ -53,8 +54,14 @@
             "(.*?)(\\.[a-f0-9]{8})?\\.(svg|png|gif|jpg|jpeg|webp)": "resources/images/$1.$3"
         }
     },
-    "browserslist": [
-        "last 2 versions",
-        "> 1%"
-    ]
+    "postcss": {
+        "plugins": {
+            "autoprefixer": {
+                "overrideBrowserslist": [
+                    "> 1%",
+                    "last 2 versions"
+                ]
+            }
+        }
+    }
 }

--- a/post-css.js
+++ b/post-css.js
@@ -1,0 +1,19 @@
+var fs = require('fs')
+var postcss = require('postcss')
+var minmax = require('postcss-media-minmax')
+var themeCss = 'dist/theme.css'
+
+
+fs.readFile(themeCss, 'utf8', function (err,data) {
+  if (err) {
+    return console.log(err);
+  }
+  var output = postcss()
+  .use(minmax())
+  .process(data)
+  .css
+
+  fs.writeFile(themeCss, output, 'utf8', function (err) {
+     if (err) return console.log(err);
+  });
+});


### PR DESCRIPTION
Avoiding media query conversion to width<= format
Reverting fix done for FORMS-13587 - Device Emulator not working for Core components based Forms (#52)
This fix will not impact inline-* styles

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
