### PR TITLE
Add gutter spacing between grid columns

### DIFF
--- a/src/site/_grid.scss
+++ b/src/site/_grid.scss
@@ -19,6 +19,9 @@
 .aem-Grid {
   display: block;
   inline-size: 100%;
+  /* negative margin offsets the column gutter padding below so the
+     row's outer edge lines up with its container as before */
+  margin-inline: calc(#{$grid-gutter} / -2);
 }
 
 .aem-Grid::before,
@@ -41,6 +44,8 @@
 .aem-GridColumn {
   clear: both;
   box-sizing: border-box;
+  /* half gutter on each side: adjacent columns get a full gutter between them */
+  padding-inline: calc(#{$grid-gutter} / 2);
 }
 
 /* force showing hidden */

--- a/src/site/_variables.scss
+++ b/src/site/_variables.scss
@@ -40,3 +40,4 @@ $radio-checkbox-gap: 20px;
 //== Grid
 
 $max_col: 12;
+$grid-gutter: 20px;


### PR DESCRIPTION
## Problem

- Fields placed in a multi-column layout (e.g. two 6-colspan text inputs in one row) render **flush against each other**
- No visible gutter/padding between adjacent columns
- Affects any component, not just text inputs

## Fix

- Added a `$grid-gutter` variable (`src/site/_variables.scss`)
- `.aem-GridColumn` now gets half-gutter padding on each side, so adjacent columns get a real gap between them
- `.aem-Grid` gets a matching negative margin, so the row's outer edge stays aligned with its container (no layout shift outside the row)

## Result

- Adjacent columns now have visible spacing between them
- Overall form width/alignment is unchanged
Before : 
<img width="410" height="341" alt="image" src="https://github.com/user-attachments/assets/8beed166-8d9d-4390-8742-e67275408449" />

After : 
<img width="1655" height="284" alt="image" src="https://github.com/user-attachments/assets/7645d807-a328-4283-a96f-3d4f94a36530" />
